### PR TITLE
Fixed `brew audit` errors and added public repo option for qemu

### DIFF
--- a/arcanist.rb
+++ b/arcanist.rb
@@ -1,8 +1,6 @@
-require 'formula'
-
 class Arcanist < Formula
   homepage 'http://phabricator.org/'
-  url 'https://github.com/facebook/arcanist/tarball/master'
+  url 'https://github.com/facebook/arcanist/archive/master.tar.gz'
   version '0.1'
 
   depends_on 'libphutil'
@@ -14,7 +12,7 @@ class Arcanist < Formula
     var = `/usr/local/bin/brew --prefix libphutil`.strip
 
     # Create the path where arcanist will look for libphutil
-    FileUtils.mkdir_p 'externals/includes'
+    mkdir_p 'externals/includes'
 
     # Link arcanist to libphutil
     cd "externals/includes" do
@@ -27,7 +25,7 @@ class Arcanist < Formula
     prefix.install Dir['*']
   end
 
-  def test
+  test do
     system "true"
   end
 end

--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -1,7 +1,8 @@
 class ArmNoneEabiGcc < Formula
+  homepage "https://launchpad.net/gcc-arm-embedded"
+  version "20140609"
   url "https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q2-update/+download/gcc-arm-none-eabi-4_8-2014q2-20140609-mac.tar.bz2"
   sha256 "dbfa2170e67f30aad349581b7db8ce61f257c3a51e32943ec12a384b1dcd7cf9"
-  homepage ""
 
   resource "sources" do
     url "https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q2-update/+download/gcc-arm-none-eabi-4_8-2014q2-20140609-src.tar.bz2"
@@ -9,7 +10,7 @@ class ArmNoneEabiGcc < Formula
   end
 
   def install
-    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+    cp_r %w(arm-none-eabi, bin, lib, share), "#{prefix}/", :verbose => true
     resource('sources').stage {
       system 'tar', '-xf', 'src/gdb.tar.bz2'
       Dir.chdir "gdb"

--- a/libphutil.rb
+++ b/libphutil.rb
@@ -1,11 +1,6 @@
-require 'formula'
-
-# Documentation: https://github.com/mxcl/homebrew/wiki/Formula-Cookbook
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
-
 class Libphutil < Formula
   homepage 'http://phabricator.org/'
-  url 'https://github.com/facebook/libphutil/tarball/master'
+  url 'https://github.com/facebook/libphutil/archive/master.tar.gz'
   version '0.1'
 
   keg_only 'Only used as a library for arcanist'
@@ -16,7 +11,7 @@ class Libphutil < Formula
     prefix.install Dir['*']
   end
 
-  def test
+  test do
     system "true"
   end
 end

--- a/pebble-openocd.rb
+++ b/pebble-openocd.rb
@@ -1,12 +1,7 @@
-# Documentation: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md
-#                /usr/local/Library/Contributions/example-formula.rb
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
-
 class PebbleOpenocd < Formula
-  homepage ""
+  homepage "https://github.com/pebble/openocd"
   url "https://github.com/pebble/openocd.git", :branch => "pebble_fork"
   version "0.9"
-  sha256 ""
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -26,6 +21,6 @@ class PebbleOpenocd < Formula
                           "--enable-maintainer-mode",
                           "--enable-ftdi",
                           "--prefix=#{prefix}"
-    system "make", "install" # if this fails, try separate make/make install steps
+    system "make", "install"
   end
 end

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -20,7 +20,8 @@ class PebbleQemu < Formula
                           "--enable-debug",
                           '--target-list=arm-softmmu',
                           "--extra-cflags=-DSTM32_UART_NO_BAUD_DELAY",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--disable-mouse"
 
     system "make", "install"
   end

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -1,7 +1,13 @@
 class PebbleQemu < Formula
   homepage "https://github.com/pebble/qemu"
-  url "https://github.com/pebble/qemu.git"
+  url "git@github.com:pebble/qemu-dev.git", :using => :git
   version "2.1.1"
+
+  option "with-public-repo", "Build using the public Pebble QEMU repo"
+
+  if build.with? "public-repo"
+    url "git@github.com:pebble/qemu.git", :using => :git
+  end
 
   depends_on "pkg-config" => :build
   depends_on "glib" => :build

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -1,13 +1,9 @@
-# Documentation: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md
-#                /usr/local/Library/Contributions/example-formula.rb
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!  
 class PebbleQemu < Formula
-  homepage ""
+  homepage "https://github.com/pebble/qemu"
   url "https://github.com/pebble/qemu.git"
-  version "head"
-  sha256 ""
+  version "2.1.1"
 
-  depends_on "pkgconfig" => :build
+  depends_on "pkg-config" => :build
   depends_on "glib" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -20,6 +16,6 @@ class PebbleQemu < Formula
                           "--extra-cflags=-DSTM32_UART_NO_BAUD_DELAY",
                           "--prefix=#{prefix}"
 
-    system "make", "install" # if this fails, try separate make/make install steps
+    system "make", "install"
   end
 end


### PR DESCRIPTION
To verify brew audit errors are fixed: 
`brew audit ./*.rb`
(should return without any output)

To test installing private QEMU: 
`brew install --verbose --debug pebble-qemu.rb` 
(note that the git repo that appears in the output is `git@github.com:pebble/qemu-dev.git`)

To test installing public QEMU: 
`brew install --verbose --debug --with-public-repo pebble-qemu.rb` 
(note that the git repo that appears in the output is `git@github.com:pebble/qemu.git`)
