### PR TITLE
Fixed arm-none-eabi-gcc formula

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -10,7 +10,7 @@ class ArmNoneEabiGcc < Formula
   end
 
   def install
-    cp_r %w(arm-none-eabi, bin, lib, share), "#{prefix}/", :verbose => true
+    prefix.install 'arm-none-eabi', 'bin', 'lib', 'share'
     resource('sources').stage {
       system 'tar', '-xf', 'src/gdb.tar.bz2'
       Dir.chdir "gdb"

--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -9,12 +9,23 @@ class ArmNoneEabiGcc < Formula
     sha256 "5c0843c5e4897ab3379523c2094208c0a7192a74d5bf25a9e545295696563e5a"
   end
 
+  option "with-brewed-python", "Use the Homebrew version of Python"
+
   def install
     prefix.install 'arm-none-eabi', 'bin', 'lib', 'share'
     resource('sources').stage {
       system 'tar', '-xf', 'src/gdb.tar.bz2'
       Dir.chdir "gdb"
-      system './configure', "--prefix=#{prefix}", '--target=arm-none-eabi', "--with-python=yes"
+      args = [
+        "--prefix=#{prefix}",
+        "--target=arm-none-eabi"
+      ]
+      if build.with? 'brewed-python'
+        args << "--with-python=#{HOMEBREW_PREFIX}"
+      else
+        args << "--with-python=yes"
+      end
+      system './configure', *args
       system 'make'
       system 'make install'
     }


### PR DESCRIPTION
As part of #1 for the arm-none-eabi-gcc formula, I replaced the `system 'cp'` command with Ruby's `cp_r` to fix an error reported by `brew audit`, but I didn't test it and for some reason `cp_r` can't see the files to copy. This PR fixes the problem by switching to using `prefix.install`. I also tested all of the formulas in this repo to make sure they work after my changes from #1.

I also added a `--with-brewed-python` option to the arm-none-eabi-gcc formula which, if provided, will build arm-none-eabi-gdb with python support using the Homebrew-installed version of Python.
